### PR TITLE
Escape the < character to fix the HTML parse errors

### DIFF
--- a/src/readingtime.js
+++ b/src/readingtime.js
@@ -53,7 +53,7 @@ module.exports = class Readingtime {
     let pt = this.options.prefixText;
     if (readingtime < 1) {
       pd = true;
-      pt = '< ';
+      pt = '&lt; ';
       readingtime = 1;
     }
 


### PR DESCRIPTION
When the reading time is less than a minute, `< 1 min` is shown. But as the `<` character is not escaped, it's causing errors like `EleventyTemplateError`, `Transform htmlmin encountered an error when transforming ./blog/file.md. (via EleventyTransformError)` and `Parse Error: < 1 min read</p>`.